### PR TITLE
Update default Node.js version to v6.9.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Upgrade ready CLI tool.
 
 With this tool you can check your installed dependencies against a specific Node.js version.
 
-We made this tool with much <3 to help you in the process to upgrade your application to the recent versions of Node.js (6.9.1)
+We made this tool with much <3 to help you in the process to upgrade your application to the recent versions of Node.js (6.9.2)
 
 The tool connect with a remote server where we try to install your dependencies tree using the selected Node.js version.
 
@@ -20,7 +20,7 @@ $ [sudo] npm install -g upgrade-ready
 Make sure you run the tool after installing dependencies with `npm install` on your working Node.js or io.js setup
 
 ``` bash
-$ upgrade-ready 6.9.1
+$ upgrade-ready 6.9.2
 ```
 
 For help message:

--- a/upgrade-ready.js
+++ b/upgrade-ready.js
@@ -24,7 +24,7 @@ var urlJoin = require('url-join')
 var config = rc('upgrade-ready', {
   endpoint: 'http://upgrade-ready.nodesource.com/api/',
   verbose: false,
-  targetVersion: '6.9.1',
+  targetVersion: '6.9.2',
   path: path.resolve('.')
 })
 


### PR DESCRIPTION
Node.js v6.9.2 just released: https://nodejs.org/en/blog/release/v6.9.2/